### PR TITLE
Fixed spelling in Electrical engine

### DIFF
--- a/materials.js
+++ b/materials.js
@@ -662,7 +662,7 @@ const materials  = [
 		value: "69000",
 		toMake: [
 			{
-				thing: "insulateWire",
+				thing: "insulatedWire",
 				quantity: "50"
 			}, {
 				thing: "aluminumBar",


### PR DESCRIPTION
It was spelling mistake in Insulatedwire which stopped to Electrical engine correctly.